### PR TITLE
Sync changes from upstream

### DIFF
--- a/src/common/data-preparer.js
+++ b/src/common/data-preparer.js
@@ -14,7 +14,7 @@ import { Utils } from './utils';
 const DEFAULT_INDEX_ROW_SEAT_TOP_OFFSET = 50;
 const DEFAULT_INDEX_ROW_SEAT_HEIGHT = 50;
 
-const SEAT_FEATURES_ICONS = {
+export const SEAT_FEATURES_ICONS = {
   '+': '<svg width="20" height="20" viewBox="-1 -1 22 22" xmlns="http://www.w3.org/2000/svg"><path d="M10 0C4.48 0 0 4.48 0 10C0 15.52 4.48 20 10 20C15.52 20 20 15.52 20 10C20 4.48 15.52 0 10 0ZM7.29 14.29L3.7 10.7C3.31 10.31 3.31 9.68 3.7 9.29C4.09 8.9 4.72 8.9 5.11 9.29L8 12.17L14.88 5.29C15.27 4.9 15.9 4.9 16.29 5.29C16.68 5.68 16.68 6.31 16.29 6.7L8.7 14.29C8.32 14.68 7.68 14.68 7.29 14.29Z" fill="#11d900"></path></svg>',
   '-': '<svg width="20" height="20" viewBox="-1 -1 22 22" xmlns="http://www.w3.org/2000/svg"><path d="M11.89 6.7L10 8.59L8.11 6.7C7.72 6.31 7.09 6.31 6.7 6.7C6.31 7.09 6.31 7.72 6.7 8.11L8.59 10L6.7 11.89C6.31 12.28 6.31 12.91 6.7 13.3C7.09 13.69 7.72 13.69 8.11 13.3L10 11.41L11.89 13.3C12.28 13.69 12.91 13.69 13.3 13.3C13.69 12.91 13.69 12.28 13.3 11.89L11.41 10L13.3 8.11C13.69 7.72 13.69 7.09 13.3 6.7C12.91 6.32 12.27 6.32 11.89 6.7ZM10 0C4.47 0 0 4.47 0 10C0 15.53 4.47 20 10 20C15.53 20 20 15.53 20 10C20 4.47 15.53 0 10 0ZM10 18C5.59 18 2 14.41 2 10C2 5.59 5.59 2 10 2C14.41 2 18 5.59 18 10C18 14.41 14.41 18 10 18Z" fill="red"></path></svg>',
   wifi: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 15.23 11"><title>wifi</title><path d="M6.62,9.91A1.08,1.08,0,1,0,7.7,8.82,1.08,1.08,0,0,0,6.62,9.91M7.7,7.64A2.24,2.24,0,0,1,9.84,9.26L11,8a3.76,3.76,0,0,0-6.65.09L5.54,9.32A2.25,2.25,0,0,1,7.7,7.64m0-3.06a5.25,5.25,0,0,1,4.37,2.35l1.08-1.15a6.75,6.75,0,0,0-11,.14L3.25,7A5.26,5.26,0,0,1,7.69,4.58m0-3a8.19,8.19,0,0,1,6.45,3.15l1.08-1.14A9.73,9.73,0,0,0,0,3.78L1.11,4.89A8.22,8.22,0,0,1,7.7,1.56" fill="#4f6f8f"/></svg>',
@@ -443,7 +443,7 @@ export class JetsContentPreparer {
     return { features: preparedFeatures, measurements: preparedMeasurements };
   };
 
-  _prepareSeatAdditionalProps = seat => {
+  prepareSeatAdditionalProps = seat => {
     const { additionalProps } = seat || {};
 
     const preparedAdditionalProps = additionalProps?.map(item => {

--- a/src/components/SeatMap/service.handlers.test.js
+++ b/src/components/SeatMap/service.handlers.test.js
@@ -1,6 +1,18 @@
-import { DEFAULT_SEAT_PASSENGER_TYPES, ENTITY_STATUS_MAP, ENTITY_TYPE_MAP } from '../../common';
+import {
+  DEFAULT_SEAT_PASSENGER_TYPES,
+  ENTITY_STATUS_MAP,
+  ENTITY_TYPE_MAP,
+  SEAT_FEATURES_ICONS,
+  Utils,
+} from '../../common';
 import { JetsSeatMapService } from './service';
 import { createPassenger, createRow, createSeatsMapService } from './service.test';
+
+beforeEach(() => {
+  jest.resetAllMocks();
+});
+
+jest.mock('../../common/utils');
 
 describe('JetsSeatMapService handlers', () => {
   describe('selectSeatHandler', () => {
@@ -347,6 +359,191 @@ describe('JetsSeatMapService handlers', () => {
           ],
         },
       ]);
+    });
+
+    it.each([
+      [
+        'should return the specified cssClass, label & icon in additionalProps (seat-specific)',
+        {
+          cssClass: 'class',
+          label: 'additionalProp',
+          iconName: '+',
+          expectedIcon: SEAT_FEATURES_ICONS['+'],
+        },
+      ],
+      [
+        'should return dot icon in additionalProps if none specified in availability additionalProps (seat-specific)',
+        {
+          cssClass: 'class',
+          label: 'additionalProp',
+          iconName: null,
+          expectedIcon: SEAT_FEATURES_ICONS['dot'],
+        },
+      ],
+      [
+        'should return empty icon in additionalProps if invalid icon name specified in availability additionalProps (seat-specific)',
+        {
+          cssClass: 'class',
+          label: 'additionalProp',
+          iconName: 'invalidIcon',
+          expectedIcon: '',
+        },
+      ],
+    ])('%s', (_, { cssClass, label, iconName, expectedIcon }) => {
+      const service = createSeatsMapService();
+
+      const content = [
+        {
+          rows: [createRow([{ type: ENTITY_TYPE_MAP.seat, number: '33A' }])],
+        },
+      ];
+      const availability = [
+        {
+          label: '33A',
+          currency: '$',
+          price: '9.99',
+          onlyForPassengerType: ['Type1', 'Type2'],
+          color: 'magenta',
+          additionalProps: [
+            {
+              icon: iconName,
+              label: label,
+              cssClass: cssClass,
+            },
+          ],
+        },
+      ];
+
+      const uniqId = '_random';
+      const mockGenerateId = jest.fn().mockReturnValue(uniqId);
+      Utils.generateId = mockGenerateId;
+
+      const response = service.setAvailabilityHandler(content, availability);
+
+      expect(response).toEqual([
+        {
+          rows: [
+            {
+              seats: [
+                {
+                  type: ENTITY_TYPE_MAP.seat,
+                  number: '33A',
+                  status: ENTITY_STATUS_MAP.available,
+                  price: '$ 9.99',
+                  cost: '9.99',
+                  currency: '$',
+                  passengerTypes: ['Type1', 'Type2'],
+                  additionalProps: [
+                    {
+                      cssClass: cssClass,
+                      icon: expectedIcon,
+                      title: null,
+                      uniqId: uniqId,
+                      value: label,
+                    },
+                  ],
+                  color: 'magenta',
+                },
+              ],
+            },
+          ],
+        },
+      ]);
+
+      expect(mockGenerateId).toHaveBeenCalledTimes(1);
+    });
+
+    it.each([
+      [
+        'should return the specified cssClass, label & icon in additionalProps (wildcard)',
+        {
+          cssClass: 'class',
+          label: 'additionalProp',
+          iconName: '+',
+          expectedIcon: SEAT_FEATURES_ICONS['+'],
+        },
+      ],
+      [
+        'should return dot icon in additionalProps if none specified in availability additionalProps (wildcard)',
+        {
+          cssClass: 'class',
+          label: 'additionalProp',
+          iconName: null,
+          expectedIcon: SEAT_FEATURES_ICONS['dot'],
+        },
+      ],
+      [
+        'should return empty icon in additionalProps if invalid icon name specified in availability additionalProps (wildcard)',
+        {
+          cssClass: 'class',
+          label: 'additionalProp',
+          iconName: 'invalidIcon',
+          expectedIcon: '',
+        },
+      ],
+    ])('%s', (_, { cssClass, label, iconName, expectedIcon }) => {
+      const service = createSeatsMapService();
+
+      const content = [
+        {
+          rows: [createRow([{ type: ENTITY_TYPE_MAP.seat, number: '33A' }])],
+        },
+      ];
+      const availability = [
+        {
+          label: '*',
+          currency: '$',
+          price: '9.99',
+          onlyForPassengerType: ['Type1', 'Type2'],
+          color: 'magenta',
+          additionalProps: [
+            {
+              icon: iconName,
+              label: label,
+              cssClass: cssClass,
+            },
+          ],
+        },
+      ];
+
+      const uniqId = '_random';
+      const mockGenerateId = jest.fn().mockReturnValue(uniqId);
+      Utils.generateId = mockGenerateId;
+
+      const response = service.setAvailabilityHandler(content, availability);
+
+      expect(response).toEqual([
+        {
+          rows: [
+            {
+              seats: [
+                {
+                  type: ENTITY_TYPE_MAP.seat,
+                  number: '33A',
+                  status: ENTITY_STATUS_MAP.available,
+                  price: '$ 9.99',
+                  cost: '9.99',
+                  currency: '$',
+                  passenger: null,
+                  passengerTypes: ['Type1', 'Type2'],
+                  additionalProps: [
+                    {
+                      cssClass: cssClass,
+                      icon: expectedIcon,
+                      title: null,
+                      uniqId: uniqId,
+                      value: label,
+                    },
+                  ],
+                  color: 'magenta',
+                },
+              ],
+            },
+          ],
+        },
+      ]);
+
+      expect(mockGenerateId).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/components/SeatMap/service.js
+++ b/src/components/SeatMap/service.js
@@ -113,7 +113,7 @@ export class JetsSeatMapService {
               );
             }
 
-            seat['additionalProps'] = this._preparer._prepareSeatAdditionalProps(seat);
+            seat['additionalProps'] = this._preparer.prepareSeatAdditionalProps(seat);
 
             return seat;
           });


### PR DESCRIPTION
* Rename function JetsContentPreparer.prepareSeatAdditionalProps (previously ._prepareSeatAdditionalProps) since it is used as a public method by external callers.
* Add export to data-preparer.js/SEAT_FEATURES_ICONS to allow use in tests.
* Add tests to service.handlers.test.js that check additionalProps are populated correctly for setAvailabilityHandler.