### PR TITLE
Sync changes from upstream

### DIFF
--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -224,7 +224,7 @@ export const THEME_FUSELAGE_WINGS_COLOR = 'darkgrey';
 
 export const THEME_DEFAULT_PASSENGER_BADGE_COLOR = '#1157ce';
 export const THEME_DEFAULT_PASSENGER_BADGE_LABEL_COLOR = 'rgb(255,255,255)';
-export const THEME_DEFAULT_PASSENGER_BADGE_BORDER_COLOR = 'none';
+export const THEME_DEFAULT_PASSENGER_BADGE_BORDER_COLOR = 'transparent';
 export const THEME_DEFAULT_FONT_FAMILY = 'Montserrat, sans-serif';
 
 export const THEME_TOOLTIP_BACKGROUND_COLOR = 'rgb(255,255,255)';


### PR DESCRIPTION
Change THEME_DEFAULT_PASSENGER_BADGE_BORDER_COLOR to 'transparent' (previously 'none'). (#69)