### PR TITLE
App 97867 screen size changes

### DIFF
--- a/src/components/SeatMap/SeatMap.js
+++ b/src/components/SeatMap/SeatMap.js
@@ -114,6 +114,7 @@ export const JetsSeatMap = ({
 
   const [exits, setExits] = useState([]);
   const [bulks, setBulks] = useState([]);
+  const [planeFeatures, setPlaneFeatures] = useState(null);
 
   const hasReceivedFirstParams = useRef(false);
   const seatMapRef = useRef();
@@ -129,24 +130,9 @@ export const JetsSeatMap = ({
 
     if (flight?.id) {
       service
-        .getSeatMapData(flight, availability, passengers, configuration)
-        .then(data => {
-          if (isMounted) {
-            setParams(data.params);
-            setContent(data.content);
-            setExits(data.exits);
-            setBulks(data.bulks);
-            setSeatMapInited(true);
-            onSeatMapInited({
-              heightInPx: data.params?.isHorizontal ? data.params?.innerWidth : data.params?.totalDecksHeight,
-              widthInPx: data.params?.isHorizontal ? data.params?.totalDecksHeight : data.params?.innerWidth,
-              scaleFactor: data.params?.scale,
-              decksCount: data.content?.length,
-              currentDeckIndex: activeDeck,
-              availabilityData: data?.availabilityData,
-            });
-            hasReceivedFirstParams.current = false;
-          }
+        .getPlaneFeatures(flight, configuration.lang, configuration.units)
+        .then(planeFeatures => {
+          setPlaneFeatures(planeFeatures);
         })
         .catch(err => {
           if (isMounted) {
@@ -166,6 +152,34 @@ export const JetsSeatMap = ({
       isMounted = false;
     };
   }, [flight]);
+
+  useEffect(() => {
+    let isMounted = true;
+    if (planeFeatures) {
+      service.processPlaneFeatures(planeFeatures, availability, passengers, configuration).then(data => {
+        if (isMounted) {
+          setParams(data.params);
+          setContent(data.content);
+          setExits(data.exits);
+          setBulks(data.bulks);
+          setSeatMapInited(true);
+          onSeatMapInited({
+            heightInPx: data.params?.isHorizontal ? data.params?.innerWidth : data.params?.totalDecksHeight,
+            widthInPx: data.params?.isHorizontal ? data.params?.totalDecksHeight : data.params?.innerWidth,
+            scaleFactor: data.params?.scale,
+            decksCount: data.content?.length,
+            currentDeckIndex: activeDeck,
+            availabilityData: data?.availabilityData,
+          });
+          hasReceivedFirstParams.current = false;
+        }
+      });
+    }
+
+    return () => {
+      isMounted = false;
+    };
+  }, [planeFeatures, configuration.width]);
 
   useEffect(() => {
     if (!availability) return;

--- a/src/components/SeatMap/SeatMap.test.js
+++ b/src/components/SeatMap/SeatMap.test.js
@@ -297,6 +297,72 @@ describe('JetsSeatMap', () => {
     });
   });
 
+  describe('when configuration.width changes', () => {
+    it('should call processPlaneFeatures again with the new width', async () => {
+      const flight = flightDetails();
+      const seatAvailability = [availability()];
+      const passengers = [passenger()];
+      const params = paramsData();
+
+      const planeFeatures = { some: 'planeFeatures' };
+      const seatMapData = {
+        params,
+        content: [],
+        exits: [[]],
+        bulks: [[]],
+        availabilityData: seatAvailability,
+      };
+
+      const mockGetPlaneFeatures = jest.fn().mockResolvedValue(planeFeatures);
+      const mockProcessPlaneFeatures = jest.fn().mockResolvedValue(seatMapData);
+      JetsSeatMapService.prototype.getPlaneFeatures = mockGetPlaneFeatures;
+      JetsSeatMapService.prototype.processPlaneFeatures = mockProcessPlaneFeatures;
+
+      const initialWidth = 600;
+      const updatedWidth = 900;
+
+      const { rerender } = setup({
+        flight,
+        availability: seatAvailability,
+        passengers: passengers,
+        currentDeckIndex: 0,
+        configOverrides: { width: initialWidth },
+      });
+
+      await waitFor(() => {
+        expect(mockGetPlaneFeatures).toHaveBeenCalledTimes(1);
+        expect(mockProcessPlaneFeatures).toHaveBeenCalledTimes(1);
+        expect(mockProcessPlaneFeatures).toHaveBeenCalledWith(
+          planeFeatures,
+          seatAvailability,
+          passengers,
+          expect.objectContaining({ width: initialWidth })
+        );
+      });
+
+      rerender(
+        <JetsSeatMap
+          flight={flight}
+          availability={seatAvailability}
+          passengers={passengers}
+          currentDeckIndex={0}
+          config={{ ...CONFIG_MOCK, width: updatedWidth }}
+        />
+      );
+
+      await waitFor(() => {
+        expect(mockGetPlaneFeatures).toHaveBeenCalledTimes(1);
+        expect(mockProcessPlaneFeatures).toHaveBeenCalledTimes(2);
+        expect(mockProcessPlaneFeatures).toHaveBeenLastCalledWith(
+          planeFeatures,
+          seatAvailability,
+          passengers,
+          expect.objectContaining({ width: updatedWidth })
+        );
+      });
+    });
+  });
+
   describe('when the seat map is called with valid flight data', () => {
     it('should render seat for a single-deck configuration', async () => {
       const planeFeatures = { some: 'planeFeatures' };

--- a/src/components/SeatMap/SeatMap.test.js
+++ b/src/components/SeatMap/SeatMap.test.js
@@ -38,11 +38,12 @@ const setup = ({
 describe('JetsSeatMap', () => {
   beforeEach(() => {
     JetsSeatMapService.prototype = {
-      getSeatMapData: jest.fn(),
-      addAbbrToPassengers: jest.fn(),
+      getPlaneFeatures: jest.fn(),
+      processPlaneFeatures: jest.fn(),
       setPassengersHandler: jest.fn(),
       setAvailabilityHandler: jest.fn(),
       compareWithDecksSeatsInfo: jest.fn(),
+      addAbbrToPassengers: jest.fn(passengers => passengers),
     };
   });
 
@@ -54,6 +55,7 @@ describe('JetsSeatMap', () => {
       const params = paramsData();
 
       const availabilityData = seatAvailability;
+      const planeFeatures = { some: 'planeFeatures' };
       const seatMapData = {
         params,
         content: [],
@@ -63,8 +65,10 @@ describe('JetsSeatMap', () => {
       };
 
       const mockOnSeatMapInited = jest.fn();
-      const mockGetSeatMapData = jest.fn().mockResolvedValue(seatMapData);
-      JetsSeatMapService.prototype.getSeatMapData = mockGetSeatMapData;
+      const mockGetPlaneFeatures = jest.fn().mockResolvedValue(planeFeatures);
+      const mockProcessPlaneFeatures = jest.fn().mockResolvedValue(seatMapData);
+      JetsSeatMapService.prototype.getPlaneFeatures = mockGetPlaneFeatures;
+      JetsSeatMapService.prototype.processPlaneFeatures = mockProcessPlaneFeatures;
 
       setup({
         flight,
@@ -76,8 +80,13 @@ describe('JetsSeatMap', () => {
 
       await waitFor(() => {
         expect(screen.queryByTestId('jets-seat-map')).toBeInTheDocument();
-        expect(mockGetSeatMapData).toHaveBeenCalledWith(
+        expect(mockGetPlaneFeatures).toHaveBeenCalledWith(
           flight,
+          expect.any(String), // not testing it was called with certain config
+          expect.any(String) // not testing it was called with certain config
+        );
+        expect(mockProcessPlaneFeatures).toHaveBeenCalledWith(
+          planeFeatures,
           seatAvailability,
           passengers,
           expect.any(Object) // not testing it was called with certain config
@@ -112,8 +121,10 @@ describe('JetsSeatMap', () => {
 
     it('should initialize the seat map with an error if an error occurred when getting seat map data', async () => {
       const mockOnSeatMapInited = jest.fn();
-      const mockGetSeatMapData = jest.fn().mockRejectedValue(new Error('An error occurred'));
-      JetsSeatMapService.prototype.getSeatMapData = mockGetSeatMapData;
+      const mockGetPlaneFeatures = jest.fn().mockRejectedValue(new Error('An error occurred'));
+      const mockProcessPlaneFeatures = jest.fn();
+      JetsSeatMapService.prototype.getPlaneFeatures = mockGetPlaneFeatures;
+      JetsSeatMapService.prototype.processPlaneFeatures = mockProcessPlaneFeatures;
 
       setup({
         flight: flightDetails(),
@@ -133,16 +144,17 @@ describe('JetsSeatMap', () => {
           currentDeckIndex: undefined,
           error: 'An error occurred',
         });
+        expect(mockProcessPlaneFeatures).not.toHaveBeenCalled();
       });
     });
   });
 
   describe('when the seat map is passed valid config and params', () => {
     it('should render the wings if visibleWings is set to true in params', async () => {
+      const params = paramsData({ visibleWings: true });
+      const planeFeatures = { some: 'planeFeatures' };
       const seatMapDataForOneDeck = {
-        params: paramsData({
-          visibleWings: true,
-        }),
+        params,
         content: [
           finalDeck({
             rows: [
@@ -159,7 +171,8 @@ describe('JetsSeatMap', () => {
         exits: [[]],
         bulks: [[]],
       };
-      JetsSeatMapService.prototype.getSeatMapData = jest.fn().mockResolvedValue(seatMapDataForOneDeck);
+      JetsSeatMapService.prototype.getPlaneFeatures = jest.fn().mockResolvedValue(planeFeatures);
+      JetsSeatMapService.prototype.processPlaneFeatures = jest.fn().mockResolvedValue(seatMapDataForOneDeck);
 
       setup({
         flight: flightDetails(),
@@ -174,10 +187,10 @@ describe('JetsSeatMap', () => {
     });
 
     it('should not render the wings if visibleWings is set to false in params', async () => {
+      const params = paramsData({ visibleWings: false });
+      const planeFeatures = { some: 'planeFeatures' };
       const seatMapDataForOneDeck = {
-        params: paramsData({
-          visibleWings: false,
-        }),
+        params,
         content: [
           finalDeck({
             rows: [
@@ -194,7 +207,8 @@ describe('JetsSeatMap', () => {
         exits: [[]],
         bulks: [[]],
       };
-      JetsSeatMapService.prototype.getSeatMapData = jest.fn().mockResolvedValue(seatMapDataForOneDeck);
+      JetsSeatMapService.prototype.getPlaneFeatures = jest.fn().mockResolvedValue(planeFeatures);
+      JetsSeatMapService.prototype.processPlaneFeatures = jest.fn().mockResolvedValue(seatMapDataForOneDeck);
 
       setup({
         flight: flightDetails(),
@@ -209,6 +223,7 @@ describe('JetsSeatMap', () => {
     });
 
     it('should render the nose and tail of the plane if visibleFuselage is set to true in config', async () => {
+      const planeFeatures = { some: 'planeFeatures' };
       const seatMapDataForOneDeck = {
         params: paramsData(),
         content: [
@@ -227,7 +242,8 @@ describe('JetsSeatMap', () => {
         exits: [[]],
         bulks: [[]],
       };
-      JetsSeatMapService.prototype.getSeatMapData = jest.fn().mockResolvedValue(seatMapDataForOneDeck);
+      JetsSeatMapService.prototype.getPlaneFeatures = jest.fn().mockResolvedValue(planeFeatures);
+      JetsSeatMapService.prototype.processPlaneFeatures = jest.fn().mockResolvedValue(seatMapDataForOneDeck);
 
       setup({
         flight: flightDetails(),
@@ -244,6 +260,7 @@ describe('JetsSeatMap', () => {
     });
 
     it('should not render the nose and tail of the plane if visibleFuselage is set to false in config', async () => {
+      const planeFeatures = { some: 'planeFeatures' };
       const seatMapDataForOneDeck = {
         params: paramsData(),
         content: [
@@ -262,7 +279,8 @@ describe('JetsSeatMap', () => {
         exits: [[]],
         bulks: [[]],
       };
-      JetsSeatMapService.prototype.getSeatMapData = jest.fn().mockResolvedValue(seatMapDataForOneDeck);
+      JetsSeatMapService.prototype.getPlaneFeatures = jest.fn().mockResolvedValue(planeFeatures);
+      JetsSeatMapService.prototype.processPlaneFeatures = jest.fn().mockResolvedValue(seatMapDataForOneDeck);
 
       setup({
         flight: flightDetails(),
@@ -281,6 +299,7 @@ describe('JetsSeatMap', () => {
 
   describe('when the seat map is called with valid flight data', () => {
     it('should render seat for a single-deck configuration', async () => {
+      const planeFeatures = { some: 'planeFeatures' };
       const seatMapDataForOneDeck = {
         params: paramsData(),
         content: [
@@ -300,7 +319,8 @@ describe('JetsSeatMap', () => {
         bulks: [[]],
       };
 
-      JetsSeatMapService.prototype.getSeatMapData = jest.fn().mockResolvedValue(seatMapDataForOneDeck);
+      JetsSeatMapService.prototype.getPlaneFeatures = jest.fn().mockResolvedValue(planeFeatures);
+      JetsSeatMapService.prototype.processPlaneFeatures = jest.fn().mockResolvedValue(seatMapDataForOneDeck);
 
       setup({
         flight: flightDetails(),
@@ -318,6 +338,7 @@ describe('JetsSeatMap', () => {
     });
 
     it('should render seat availability for a single-deck configuration', async () => {
+      const planeFeatures = { some: 'planeFeatures' };
       const seatMapDataForOneDeck = {
         params: paramsData(),
         content: [
@@ -342,7 +363,8 @@ describe('JetsSeatMap', () => {
         bulks: [[]],
       };
 
-      JetsSeatMapService.prototype.getSeatMapData = jest.fn().mockResolvedValue(seatMapDataForOneDeck);
+      JetsSeatMapService.prototype.getPlaneFeatures = jest.fn().mockResolvedValue(planeFeatures);
+      JetsSeatMapService.prototype.processPlaneFeatures = jest.fn().mockResolvedValue(seatMapDataForOneDeck);
 
       setup({
         flight: flightDetails(),
@@ -367,6 +389,7 @@ describe('JetsSeatMap', () => {
     });
 
     it('should render seat passengers for a single-deck configuration', async () => {
+      const planeFeatures = { some: 'planeFeatures' };
       const seatMapDataForOneDeck = {
         params: paramsData(),
         content: [
@@ -405,7 +428,8 @@ describe('JetsSeatMap', () => {
       };
       seatMapDataForOneDeckWithAllData.content[0].rows[0].seats[0].status = 'selected';
       seatMapDataForOneDeckWithAllData.content[0].rows[0].seats[0].passenger = mockPassengerWithAbbr;
-      JetsSeatMapService.prototype.getSeatMapData = jest.fn().mockResolvedValue(seatMapDataForOneDeckWithAllData);
+      JetsSeatMapService.prototype.getPlaneFeatures = jest.fn().mockResolvedValue(planeFeatures);
+      JetsSeatMapService.prototype.processPlaneFeatures = jest.fn().mockResolvedValue(seatMapDataForOneDeckWithAllData);
 
       setup({
         flight: flightDetails(),
@@ -424,6 +448,7 @@ describe('JetsSeatMap', () => {
     });
 
     it('should render seat for a double-deck configuration, lower deck chosen', async () => {
+      const planeFeatures = { some: 'planeFeatures' };
       const seatMapDataForOneDeck = {
         params: paramsData(),
         content: [
@@ -458,8 +483,8 @@ describe('JetsSeatMap', () => {
         bulks: [[]],
       };
 
-      const mockGetSeatMapData = jest.fn().mockResolvedValue(seatMapDataForOneDeck);
-      JetsSeatMapService.prototype.getSeatMapData = mockGetSeatMapData;
+      JetsSeatMapService.prototype.getPlaneFeatures = jest.fn().mockResolvedValue(planeFeatures);
+      JetsSeatMapService.prototype.processPlaneFeatures = jest.fn().mockResolvedValue(seatMapDataForOneDeck);
 
       setup({
         flight: flightDetails(),
@@ -480,6 +505,7 @@ describe('JetsSeatMap', () => {
     });
 
     it('should render seat for a double-deck configuration, upper deck chosen', async () => {
+      const planeFeatures = { some: 'planeFeatures' };
       const seatMapDataForTwoDecks = {
         params: paramsData(),
         content: [
@@ -514,8 +540,8 @@ describe('JetsSeatMap', () => {
         bulks: [[]],
       };
 
-      const mockGetSeatMapData = jest.fn().mockResolvedValue(seatMapDataForTwoDecks);
-      JetsSeatMapService.prototype.getSeatMapData = mockGetSeatMapData;
+      JetsSeatMapService.prototype.getPlaneFeatures = jest.fn().mockResolvedValue(planeFeatures);
+      JetsSeatMapService.prototype.processPlaneFeatures = jest.fn().mockResolvedValue(seatMapDataForTwoDecks);
 
       setup({
         flight: flightDetails(),
@@ -536,6 +562,7 @@ describe('JetsSeatMap', () => {
     });
 
     it('should render bulks and exists', async () => {
+      const planeFeatures = { some: 'planeFeatures' };
       const seatMapDataForOneDeck = {
         params: paramsData(),
         content: [finalDeck()],
@@ -543,7 +570,8 @@ describe('JetsSeatMap', () => {
         bulks: [[bulk()]],
       };
 
-      JetsSeatMapService.prototype.getSeatMapData = jest.fn().mockResolvedValue(seatMapDataForOneDeck);
+      JetsSeatMapService.prototype.getPlaneFeatures = jest.fn().mockResolvedValue(planeFeatures);
+      JetsSeatMapService.prototype.processPlaneFeatures = jest.fn().mockResolvedValue(seatMapDataForOneDeck);
 
       setup({
         flight: flightDetails(),

--- a/src/components/SeatMap/service.getSeatMapData.test.js
+++ b/src/components/SeatMap/service.getSeatMapData.test.js
@@ -609,7 +609,9 @@ describe('JetsSeatMapService getSeatMapData', () => {
         };
         const availability = null;
         const passengers = null;
-        const response = await service.getSeatMapData(flight, availability, passengers, config);
+
+        const fetchedPlaneFeatures = await service.getPlaneFeatures(flight, config.lang, config.units);
+        const response = await service.processPlaneFeatures(fetchedPlaneFeatures, availability, passengers, config);
 
         expect(response).toEqual({
           content: expectedResponse.content,
@@ -646,7 +648,9 @@ describe('JetsSeatMapService getSeatMapData', () => {
         lang: 'EN',
         units: 'metric',
       };
-      const response = await service.getSeatMapData(flight, availability, passengers, config);
+
+      const fetchedPlaneFeatures = await service.getPlaneFeatures(flight, config.lang, config.units);
+      const response = await service.processPlaneFeatures(fetchedPlaneFeatures, availability, passengers, config);
 
       const expectedResponse = createExpectedResponse({
         content: [createPreparedDeck()],
@@ -676,7 +680,9 @@ describe('JetsSeatMapService getSeatMapData', () => {
         lang: 'EN',
         units: 'metric',
       };
-      const response = await service.getSeatMapData(flight, availability, passengers, config);
+
+      const fetchedPlaneFeatures = await service.getPlaneFeatures(flight, config.lang, config.units);
+      const response = await service.processPlaneFeatures(fetchedPlaneFeatures, availability, passengers, config);
 
       const expectedResponse = createExpectedResponse({
         content: [createPreparedDeck()],
@@ -716,7 +722,8 @@ describe('JetsSeatMapService getSeatMapData', () => {
             lang: 'EN',
             units: 'metric',
           };
-          const response = await service.getSeatMapData(flight, availability, passengers, config);
+          const fetchedPlaneFeatures = await service.getPlaneFeatures(flight, config.lang, config.units);
+          const response = await service.processPlaneFeatures(fetchedPlaneFeatures, availability, passengers, config);
 
           const expectedContent = [
             createPreparedDeck({
@@ -788,7 +795,8 @@ describe('JetsSeatMapService getSeatMapData', () => {
             lang: lang,
             units: 'metric',
           };
-          const response = await service.getSeatMapData(flight, availability, passengers, config);
+          const fetchedPlaneFeatures = await service.getPlaneFeatures(flight, config.lang, config.units);
+          const response = await service.processPlaneFeatures(fetchedPlaneFeatures, availability, passengers, config);
 
           const expectedRecline = ['doNotRecline', 'limitedRecline', 'prereclinedSeat'].includes(feature)
             ? '- -'

--- a/src/components/SeatMap/service.js
+++ b/src/components/SeatMap/service.js
@@ -19,6 +19,22 @@ export class JetsSeatMapService {
     this._configuration = configuration;
   }
 
+  getPlaneFeatures = async (flight, lang, units) => {
+    const planeFeatures = await this._api.getPlaneFeatures(flight, lang, units);
+    return planeFeatures;
+  };
+
+  processPlaneFeatures = async (planeFeatures, availability, passengers, config) => {
+    let { content, params, exits, bulks } = this._preparer.prepareData(planeFeatures, config);
+
+    if (availability) content = this.setAvailabilityHandler(content, availability);
+
+    const activePassenger = passengers?.find(item => item.seat?.seatLabel);
+    if (passengers && activePassenger) content = this.setPassengersHandler(content, passengers);
+
+    return { content, params, exits, bulks, availabilityData: planeFeatures?.availabilityData };
+  };
+
   getSeatMapData = async (flight, availability, passengers, config) => {
     const { lang, units } = config;
     const planeFeatures = await this._api.getPlaneFeatures(flight, lang, units);

--- a/src/components/SeatMap/service.js
+++ b/src/components/SeatMap/service.js
@@ -35,20 +35,6 @@ export class JetsSeatMapService {
     return { content, params, exits, bulks, availabilityData: planeFeatures?.availabilityData };
   };
 
-  getSeatMapData = async (flight, availability, passengers, config) => {
-    const { lang, units } = config;
-    const planeFeatures = await this._api.getPlaneFeatures(flight, lang, units);
-
-    let { content, params, exits, bulks } = this._preparer.prepareData(planeFeatures, config);
-
-    if (availability) content = this.setAvailabilityHandler(content, availability);
-
-    const activePassenger = passengers?.find(item => item.seat?.seatLabel);
-    if (passengers && activePassenger) content = this.setPassengersHandler(content, passengers);
-
-    return { content, params, exits, bulks, availabilityData: planeFeatures?.availabilityData };
-  };
-
   selectSeatHandler = (content, seat, passengersList) => {
     const nextPassenger = this.getNextPassenger(passengersList);
     const passengers = passengersList.map(passenger => {


### PR DESCRIPTION
https://travelperk.atlassian.net/browse/APP-97867 and https://travelperk.atlassian.net/browse/APP-100391

This splits out the API call to get plane features and the follow on processing. This means we can do the data processing on a configuration change (e.g. screen size) without it doing another API call.
The API call happens any time flight changes

The follow on processing now happens either when the planeFeatures (result from the API call) changes, or currently when configuration.width changes. 
I originally had this function when configuration changes, but then it got called all the time on the storybook, so I changed it to just the width changing for now as that's all we currently need, but it can be adapted to call when other configuration changes happen too, I'm open to changing what this gets called on.

I updated the tests in this repo and added a test that the processing happens again when width changes (but not get plane call)

I also tested manually, I tested in the storybook, and tested with the build in our frontend.
Previously, when I changed the screen size e.g. to iPhone SE, the display didn't look good.

<img width="557" alt="Screenshot 2025-05-21 at 12 16 41" src="https://github.com/user-attachments/assets/b3af69d0-8eb8-4579-80e7-8199e3a47036" />


With these changes, when I changed the screen size to iPhone SE (or any other size) It re-called the process data, and the display looked nicer. 
<img width="544" alt="image" src="https://github.com/user-attachments/assets/6d705f2a-c5b5-4240-98ed-a91910498bbd" />

