### PR TITLE
allow api key to be callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ interface IConfig {
   units: TUnit;
   apiUrl: string;
   apiAppId: string;
-  apiKey: string | (() => string) | (() => Promise<string>);
+  apiKey: string | (() => string);
   colorTheme: IColorTheme;
 }
 
@@ -405,7 +405,7 @@ The `full config` looks like this:
 
   apiUrl: 'PROVIDED_API_URL',               
   apiAppId: 'PROVIDED_APP_ID',
-  apiKey: 'PROVIDED_API_KEY',                // or a sync/async callback: () => string or () => Promise<string>, for dynamic or refreshed credentials
+  apiKey: 'PROVIDED_API_KEY',                // or a callback: () => string, for dynamic or refreshed credentials
   apiAuthorizationScheme: 'Bearer',            // authorization scheme to be sent in API client requests 'Authorization' header (default: 'Bearer', e.g. 'Authorization: Bearer {apiKey}')
   apiMetadata: {                            // any proprietary data to be passed in the POST request to /flight/features/plane/seatmap (e.g. for custom monitoring)
     'PROPRIETARY_KEY': 'PROPRIETARY_VALUE',

--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ interface IConfig {
   units: TUnit;
   apiUrl: string;
   apiAppId: string;
-  apiKey: string;
+  apiKey: string | (() => string) | (() => Promise<string>);
   colorTheme: IColorTheme;
 }
 
@@ -405,7 +405,7 @@ The `full config` looks like this:
 
   apiUrl: 'PROVIDED_API_URL',               
   apiAppId: 'PROVIDED_APP_ID',
-  apiKey: 'PROVIDED_API_KEY',
+  apiKey: 'PROVIDED_API_KEY',                // or a sync/async callback: () => string or () => Promise<string>, for dynamic or refreshed credentials
   apiAuthorizationScheme: 'Bearer',            // authorization scheme to be sent in API client requests 'Authorization' header (default: 'Bearer', e.g. 'Authorization: Bearer {apiKey}')
   apiMetadata: {                            // any proprietary data to be passed in the POST request to /flight/features/plane/seatmap (e.g. for custom monitoring)
     'PROPRIETARY_KEY': 'PROPRIETARY_VALUE',

--- a/src/common/api.js
+++ b/src/common/api.js
@@ -68,11 +68,10 @@ export class JetsApiService {
     };
   };
 
-  _resolveApiKey = async () => {
+  _resolveApiKey = () => {
     const key = this._apiKey;
     if (typeof key === 'function') {
-      const result = key();
-      return typeof result?.then === 'function' ? result : Promise.resolve(result);
+      return key();
     }
     return key;
   };
@@ -82,7 +81,7 @@ export class JetsApiService {
 
     if (token) return token;
 
-    const resolvedKey = await this._resolveApiKey();
+    const resolvedKey = this._resolveApiKey();
     const path = `auth?appId=${this._appId}`;
     const { accessToken } = await this.getData(path, this._getAuthRequestOptions(resolvedKey));
 

--- a/src/common/api.js
+++ b/src/common/api.js
@@ -68,13 +68,23 @@ export class JetsApiService {
     };
   };
 
+  _resolveApiKey = async () => {
+    const key = this._apiKey;
+    if (typeof key === 'function') {
+      const result = key();
+      return typeof result?.then === 'function' ? result : Promise.resolve(result);
+    }
+    return key;
+  };
+
   _getToken = async () => {
     const token = this._localStorage ? this._localStorage.getData(JWT_TOKEN) : null;
 
     if (token) return token;
 
+    const resolvedKey = await this._resolveApiKey();
     const path = `auth?appId=${this._appId}`;
-    const { accessToken } = await this.getData(path, this._getAuthRequestOptions(this._apiKey));
+    const { accessToken } = await this.getData(path, this._getAuthRequestOptions(resolvedKey));
 
     if (!accessToken) {
       throw new Error('Unable to authenticate');

--- a/src/common/api.test.js
+++ b/src/common/api.test.js
@@ -1,0 +1,82 @@
+import { JetsApiService } from './api';
+import { DEFAULT_AUTHORIZATION_SCHEME } from './constants';
+
+describe('JetsApiService', () => {
+  describe('_resolveApiKey', () => {
+    it('should return the key when apiKey is a string', async () => {
+      const service = new JetsApiService('appId', 'static-key', 'https://api.example.com', null);
+      const result = await service._resolveApiKey();
+      expect(result).toBe('static-key');
+    });
+
+    it('should call sync callback and return its value when apiKey is a function', async () => {
+      const callback = jest.fn().mockReturnValue('callback-key');
+      const service = new JetsApiService('appId', callback, 'https://api.example.com', null);
+      const result = await service._resolveApiKey();
+      expect(callback).toHaveBeenCalledTimes(1);
+      expect(result).toBe('callback-key');
+    });
+
+    it('should await async callback and return its value when apiKey returns a Promise', async () => {
+      const callback = jest.fn().mockResolvedValue('async-callback-key');
+      const service = new JetsApiService('appId', callback, 'https://api.example.com', null);
+      const result = await service._resolveApiKey();
+      expect(callback).toHaveBeenCalledTimes(1);
+      expect(result).toBe('async-callback-key');
+    });
+  });
+
+  describe('_getToken with apiKey callback', () => {
+    it('should use resolved key from sync callback for auth request', async () => {
+      const apiKeyCallback = jest.fn().mockReturnValue('resolved-sync-key');
+      const service = new JetsApiService('appId', apiKeyCallback, 'https://api.example.com', null);
+
+      const getDataSpy = jest.spyOn(service, 'getData').mockImplementation(async (url, options = {}) => {
+        if (url.startsWith('auth?')) {
+          return { accessToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHA6OTk5OTk5OTk5OX0.x' };
+        }
+        return {};
+      });
+
+      await service._getToken();
+
+      expect(apiKeyCallback).toHaveBeenCalled();
+      expect(getDataSpy).toHaveBeenCalledWith(
+        'auth?appId=appId',
+        expect.objectContaining({
+          headers: {
+            authorization: `${DEFAULT_AUTHORIZATION_SCHEME} resolved-sync-key`,
+          },
+        })
+      );
+
+      getDataSpy.mockRestore();
+    });
+
+    it('should use resolved key from async callback for auth request', async () => {
+      const apiKeyCallback = jest.fn().mockResolvedValue('resolved-async-key');
+      const service = new JetsApiService('appId', apiKeyCallback, 'https://api.example.com', null);
+
+      const getDataSpy = jest.spyOn(service, 'getData').mockImplementation(async (url) => {
+        if (url.startsWith('auth?')) {
+          return { accessToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHA6OTk5OTk5OTk5OX0.x' };
+        }
+        return {};
+      });
+
+      await service._getToken();
+
+      expect(apiKeyCallback).toHaveBeenCalled();
+      expect(getDataSpy).toHaveBeenCalledWith(
+        'auth?appId=appId',
+        expect.objectContaining({
+          headers: {
+            authorization: `${DEFAULT_AUTHORIZATION_SCHEME} resolved-async-key`,
+          },
+        })
+      );
+
+      getDataSpy.mockRestore();
+    });
+  });
+});

--- a/src/common/api.test.js
+++ b/src/common/api.test.js
@@ -31,9 +31,9 @@ describe('JetsApiService', () => {
       const apiKeyCallback = jest.fn().mockReturnValue('resolved-sync-key');
       const service = new JetsApiService('appId', apiKeyCallback, 'https://api.example.com', null);
 
-      const getDataSpy = jest.spyOn(service, 'getData').mockImplementation(async (url, options = {}) => {
+      const getDataSpy = jest.spyOn(service, 'getData').mockImplementation(async (url) => {
         if (url.startsWith('auth?')) {
-          return { accessToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHA6OTk5OTk5OTk5OX0.x' };
+          return { accessToken: 'mock-access-token' };
         }
         return {};
       });
@@ -59,7 +59,7 @@ describe('JetsApiService', () => {
 
       const getDataSpy = jest.spyOn(service, 'getData').mockImplementation(async (url) => {
         if (url.startsWith('auth?')) {
-          return { accessToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHA6OTk5OTk5OTk5OX0.x' };
+          return { accessToken: 'mock-access-token' };
         }
         return {};
       });

--- a/src/common/api.test.js
+++ b/src/common/api.test.js
@@ -3,26 +3,18 @@ import { DEFAULT_AUTHORIZATION_SCHEME } from './constants';
 
 describe('JetsApiService', () => {
   describe('_resolveApiKey', () => {
-    it('should return the key when apiKey is a string', async () => {
+    it('should return the key when apiKey is a string', () => {
       const service = new JetsApiService('appId', 'static-key', 'https://api.example.com', null);
-      const result = await service._resolveApiKey();
+      const result = service._resolveApiKey();
       expect(result).toBe('static-key');
     });
 
-    it('should call sync callback and return its value when apiKey is a function', async () => {
+    it('should call sync callback and return its value when apiKey is a function', () => {
       const callback = jest.fn().mockReturnValue('callback-key');
       const service = new JetsApiService('appId', callback, 'https://api.example.com', null);
-      const result = await service._resolveApiKey();
+      const result = service._resolveApiKey();
       expect(callback).toHaveBeenCalledTimes(1);
       expect(result).toBe('callback-key');
-    });
-
-    it('should await async callback and return its value when apiKey returns a Promise', async () => {
-      const callback = jest.fn().mockResolvedValue('async-callback-key');
-      const service = new JetsApiService('appId', callback, 'https://api.example.com', null);
-      const result = await service._resolveApiKey();
-      expect(callback).toHaveBeenCalledTimes(1);
-      expect(result).toBe('async-callback-key');
     });
   });
 
@@ -46,32 +38,6 @@ describe('JetsApiService', () => {
         expect.objectContaining({
           headers: {
             authorization: `${DEFAULT_AUTHORIZATION_SCHEME} resolved-sync-key`,
-          },
-        })
-      );
-
-      getDataSpy.mockRestore();
-    });
-
-    it('should use resolved key from async callback for auth request', async () => {
-      const apiKeyCallback = jest.fn().mockResolvedValue('resolved-async-key');
-      const service = new JetsApiService('appId', apiKeyCallback, 'https://api.example.com', null);
-
-      const getDataSpy = jest.spyOn(service, 'getData').mockImplementation(async (url) => {
-        if (url.startsWith('auth?')) {
-          return { accessToken: 'mock-access-token' };
-        }
-        return {};
-      });
-
-      await service._getToken();
-
-      expect(apiKeyCallback).toHaveBeenCalled();
-      expect(getDataSpy).toHaveBeenCalledWith(
-        'auth?appId=appId',
-        expect.objectContaining({
-          headers: {
-            authorization: `${DEFAULT_AUTHORIZATION_SCHEME} resolved-async-key`,
           },
         })
       );


### PR DESCRIPTION
For this [issue](https://travelperk.atlassian.net/browse/APP-109920), we want to allow `apiKey` to be a callback which can be resolved to a string, rather than just passing a static string.